### PR TITLE
Added a Getter for the Bounds of a Panel

### DIFF
--- a/nk/etc.go
+++ b/nk/etc.go
@@ -229,3 +229,7 @@ func (l *ListView) End() int {
 func (l *ListView) Count() int {
 	return (int)(l.count)
 }
+
+func (panel *Panel) Bounds() *Rect {
+	return (*Rect)(&panel.bounds)
+}


### PR DESCRIPTION
I needed the bounds of a panel to port the node_editor demo (from the original nuklear repo) to go.