### PR TITLE
Add FontConfig.SetRange(*Rune) for CJK fonts

### DIFF
--- a/nk/etc.go
+++ b/nk/etc.go
@@ -97,6 +97,10 @@ func NkFontAtlasAddFromBytes(atlas *FontAtlas, data []byte, height float32, conf
 	return NkFontAtlasAddFromMemory(atlas, dataPtr, Size(len(data)), height, config)
 }
 
+func (fc *FontConfig) SetRange(r *Rune) {
+	fc._range = (*C.nk_rune)(r)
+}
+
 func (h Handle) ID() int {
 	return int(*(*int64)(unsafe.Pointer(&h)))
 }


### PR DESCRIPTION
Example:
```go
fc := nk.NkFontConfig(0)
fc.SetRange(nk.NkFontChineseGlyphRanges())
sansFont := nk.NkFontAtlasAddFromBytes(atlas, MustAsset("assets/GenShinGothic-P-Regular.ttf"), 16, &fc)
```
![screen shot 2017-12-30 at 19 16 26](https://user-images.githubusercontent.com/3931445/34453345-f9be8636-ed95-11e7-99d5-0497ad3d31e0.png)
