### PR TITLE
Add accessors for input.Keyboard().Text().

### DIFF
--- a/nk/etc.go
+++ b/nk/etc.go
@@ -54,6 +54,14 @@ func (input *Input) Mouse() *Mouse {
 	return (*Mouse)(&input.mouse)
 }
 
+func (input *Input) Keyboard() *Keyboard {
+	return (*Keyboard)(&input.keyboard)
+}
+
+func (keyboard *Keyboard) Text() string {
+	return C.GoStringN(&keyboard.text[0], keyboard.text_len)
+}
+
 func (mouse *Mouse) Grab() bool {
 	return mouse.grab == True
 }


### PR DESCRIPTION
`input.Keyboard().Text()` now returns a string with any keys entered in the last frame.

(Just adds the few missing Go functions to traverse the structure and convert string. :))