### PR TITLE
Handle keypad enter key identicaly to normal enter key

### DIFF
--- a/nk/impl_glfw_common.go
+++ b/nk/impl_glfw_common.go
@@ -96,6 +96,7 @@ func NkPlatformNewFrame() {
 
 	NkInputKey(ctx, KeyDel, keyPressed(win, glfw.KeyDelete))
 	NkInputKey(ctx, KeyEnter, keyPressed(win, glfw.KeyEnter))
+	NkInputKey(ctx, KeyEnter, keyPressed(win, glfw.KeyKPEnter))
 	NkInputKey(ctx, KeyTab, keyPressed(win, glfw.KeyTab))
 	NkInputKey(ctx, KeyBackspace, keyPressed(win, glfw.KeyBackspace))
 	NkInputKey(ctx, KeyUp, keyPressed(win, glfw.KeyUp))

--- a/nk/impl_sdl2_common.go
+++ b/nk/impl_sdl2_common.go
@@ -96,6 +96,7 @@ func NkPlatformNewFrame() {
 
 	NkInputKey(ctx, KeyDel, int32(keys[sdl.SCANCODE_DELETE]))
 	NkInputKey(ctx, KeyEnter, int32(keys[sdl.SCANCODE_RETURN]))
+	NkInputKey(ctx, KeyEnter, int32(keys[sdl.SCANCODE_KP_ENTER]))
 	NkInputKey(ctx, KeyTab, int32(keys[sdl.SCANCODE_TAB]))
 	NkInputKey(ctx, KeyBackspace, int32(keys[sdl.SCANCODE_BACKSPACE]))
 	NkInputKey(ctx, KeyUp, int32(keys[sdl.SCANCODE_UP]))


### PR DESCRIPTION
NB: The sdl2 version has not been tested, but should be trivial.