### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ $ make clean
 $ make
 ```
 
+### Building nuklear - Using vcpkg
+
+You can download and install nuklear using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install nuklear
+
+The nuklear port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### License
 
 All the code except when stated otherwise is licensed under the [MIT license](https://xlab.mit-license.org).


### PR DESCRIPTION
nuklear is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for nuklear and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build nuklear, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/nuklear/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)
